### PR TITLE
feat: Add task durations

### DIFF
--- a/_entries/02-01 challenge1.md
+++ b/_entries/02-01 challenge1.md
@@ -1,7 +1,7 @@
 ---
 sectionid: runcontainer
 sectionclass: h2
-title: Running the application within a Docker container
+title: Running the application within a Docker container (25m)
 parent-id: upandrunning
 ---
 

--- a/_entries/02-02 challenge2.md
+++ b/_entries/02-02 challenge2.md
@@ -1,7 +1,7 @@
 ---
 sectionid: containerconfig
 sectionclass: h2
-title: Customizing the containerized app
+title: Customizing the containerized app (5m)
 parent-id: upandrunning
 ---
 

--- a/_entries/02-03 challenge3.md
+++ b/_entries/02-03 challenge3.md
@@ -1,7 +1,7 @@
 ---
 sectionid: publishingtoacr
 sectionclass: h2
-title: Publishing to a Docker registry
+title: Publishing to a Docker registry (15m)
 parent-id: upandrunning
 ---
 

--- a/_entries/02-04 challenge4.md
+++ b/_entries/02-04 challenge4.md
@@ -1,7 +1,7 @@
 ---
 sectionid: deploy
 sectionclass: h2
-title: Deploying Kubernetes with Azure Kubernetes Service (AKS)
+title: Deploying Kubernetes with AKS (30m)
 parent-id: upandrunning
 ---
 

--- a/_entries/02-05 challenge5.md
+++ b/_entries/02-05 challenge5.md
@@ -1,7 +1,7 @@
 ---
 sectionid: deployingwebapptoaks
 sectionclass: h2
-title: Deploying the app to AKS
+title: Deploying the app to AKS (20m)
 parent-id: upandrunning
 ---
 

--- a/_entries/02-06 challenge6.md
+++ b/_entries/02-06 challenge6.md
@@ -1,7 +1,7 @@
 ---
 sectionid: enablingpublicaccess
 sectionclass: h2
-title: Enabling public access
+title: Enabling public access (30m)
 parent-id: upandrunning
 ---
 

--- a/_entries/02-07 challenge7.md
+++ b/_entries/02-07 challenge7.md
@@ -1,7 +1,7 @@
 ---
 sectionid: basicmonitoring
 sectionclass: h2
-title: Getting basic activity metrics
+title: Getting basic activity metrics (15m)
 parent-id: upandrunning
 ---
 


### PR DESCRIPTION
Add duration estimates for every core task (in Up and Running).

The introduction is expected to take 30 minutes, and the core tasks around 2h20m so the lab should take at least 2h50m not including any extra time spent searching for very detailed information and trying out things. 
For those familiar with Docker, the lab should be at least 40 minutes shorter and they would be able to spend more time doing advanced tasks.

Fixes #27