### PR TITLE
fix: Fix the hello-world repo clone command

### DIFF
--- a/_entries/02-01 challenge1.md
+++ b/_entries/02-01 challenge1.md
@@ -19,7 +19,7 @@ The folders are named after various programming languages, so you can choose the
 
 ```sh
 # Clone the repo
-git clone git@github.com:ikhemissi/hello-worlds.git
+git clone https://github.com/ikhemissi/hello-worlds.git
 cd hello-worlds
 
 # Choose the NodeJS version of the app


### PR DESCRIPTION
Fix the command used to git clone the repository of hello-worlds to use `https` instead of `git`.

noissue