### PR TITLE
chore: Cleanup closed PR website

### DIFF
--- a/.github/workflows/clean-closed-pr-website.yaml
+++ b/.github/workflows/clean-closed-pr-website.yaml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: azure/CLI@v1
+        name: Delete the website of the feature branch
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
+        with:
+          azcliversion: 2.44.1
+          inlineScript: |
+            az config set extension.use_dynamic_install=yes_without_prompt
+
+            BRANCH=${{ github.event.pull_request.head.ref }}
+            BRANCH=${BRANCH#refs/*/}
+            BRANCH=${BRANCH//\//-}
+
+            az storage azcopy blob delete \
+              --container "\$web" \
+              --target "${BRANCH}" \
+              --recursive


### PR DESCRIPTION
Delete the website of the feature branch of the closed PR (merged or not) using the [pull_request/closed event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges).

noissue